### PR TITLE
Adding examples files and doc for espressif's esp-idf SDK.

### DIFF
--- a/functional-testing/GPIO-esp-idf/CMakeLists.txt
+++ b/functional-testing/GPIO-esp-idf/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "GPIO.c"
+                    INCLUDE_DIRS "")

--- a/functional-testing/GPIO-esp-idf/GPIO.c
+++ b/functional-testing/GPIO-esp-idf/GPIO.c
@@ -1,0 +1,50 @@
+/* Hello World Example
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+#include <stdio.h>
+#include "sdkconfig.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+
+#ifdef CONFIG_IDF_TARGET_ESP32
+#define CHIP_NAME "ESP32"
+#endif
+
+#ifdef CONFIG_IDF_TARGET_ESP32S2BETA
+#define CHIP_NAME "ESP32-S2 Beta"
+#endif
+
+void app_main(void)
+{
+
+	gpio_config_t io_conf;
+	
+	#define GPIO_OUTPUT 4
+	#define GPIO_OUTPUT_PIN (1ULL<<GPIO_OUTPUT)
+	io_conf.intr_type = GPIO_INTR_DISABLE;
+	io_conf.mode = GPIO_MODE_OUTPUT;
+	io_conf.pin_bit_mask = GPIO_OUTPUT_PIN;
+	gpio_config(&io_conf);
+
+	#define GPIO_INPUT 18
+	#define GPIO_INPUT_PIN (1ULL<<GPIO_INPUT)
+	io_conf.intr_type = GPIO_INTR_DISABLE;
+	io_conf.mode = GPIO_MODE_INPUT;
+	io_conf.pin_bit_mask = GPIO_INPUT_PIN;
+	gpio_config(&io_conf);
+
+	uint16_t cnt=0;
+	while(1) {
+		if ( !gpio_get_level(GPIO_INPUT) )
+	        	vTaskDelay(200 / portTICK_RATE_MS);	// push
+		else
+	        	vTaskDelay(500 / portTICK_RATE_MS);
+	        gpio_set_level(GPIO_OUTPUT, cnt++ & 1);
+    	}
+}

--- a/functional-testing/GPIO-esp-idf/README.md
+++ b/functional-testing/GPIO-esp-idf/README.md
@@ -1,0 +1,14 @@
+# GPIO tests with esp-idf SDK
+
+The esp-idf SDK from Espressif allow you to go deeper with the ESP32. The code is low level and allow you to control everything in the chip. The drawback is it's slightly more complex than using the Arduino IDE.
+
+## The environment
+First, setup the SDK under your favourite OS: [Link to the Espressif web site](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html)
+Tested successfully under Linux and Windows with the Fortithing. Even with VM in Virtualbox plus USB passthrough to flash the device.
+
+## Your first own code
+The idea is to start from the `hello_world` from [step 5](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#step-5-start-a-project). 
+Copy again the template and copy the GPIO.c + CMakeLists.txt files in the folder `main`.
+To use the full flash, change the default size: run `idf.py menuconfig` go to `Serial flasher config` and set the `Flash size` to `4 MB`.
+Compile and flash the board and that's it.
+


### PR DESCRIPTION
Here is a little step-by-step to use the esp-idf SDK with fortithing.